### PR TITLE
[Fix] Use method module_parent replace for parent

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -95,7 +95,7 @@ module Devise
       end
 
       def inactive_message
-        if self.class.parent.name == "Manager" && self.withdrawn_at
+        if self.class.module_parent.name == "Manager" && self.withdrawn_at
           :company_stopped
         else
           :inactive

--- a/lib/devise/strategies/database_authenticatable.rb
+++ b/lib/devise/strategies/database_authenticatable.rb
@@ -23,7 +23,7 @@ module Devise
         unless resource
           if mapping.to.name == "Manager"
             resource = mapping.to.find_for_database_authentication(authentication_hash.merge(not_withdrawn: true))
-            if resource && (resource.class.parent.name == "Manager") && resource.withdrawn_at
+            if resource && (resource.class.module_parent.name == "Manager") && resource.withdrawn_at
               fail(:company_stopped)
             else
               Devise.paranoid ? fail(:invalid) : fail(:not_found_in_database)


### PR DESCRIPTION
### Issue
Method `parent` has been rename to `module_parent`. `parent` is deprecated and will be removed in Rails 6.1..squish)
refs: https://apidock.com/rails/v6.0.0/Module/parent

Rails 6.0: https://github.com/rails/rails/blob/6-0-stable/activesupport/lib/active_support/core_ext/module/introspection.rb#L47-L53
Rails 7: https://github.com/rails/rails/blob/7-0-stable/activesupport/lib/active_support/core_ext/module/introspection.rb#L35-L37
